### PR TITLE
Use x0 as starting point

### DIFF
--- a/src/DONEs.jl
+++ b/src/DONEs.jl
@@ -170,7 +170,7 @@ function update_optimal_input!(alg::DONE)
     opt.min_objective = myfunc
 
     x0 = project_on_bounds(alg.current_optimal_x + rand(alg.surrogate_exploration_prob_dist),alg.lower_bound,alg.upper_bound)
-    (minf,minx,ret) = NLopt.optimize(opt, zeros(Float64,alg.n))
+    (minf,minx,ret) = NLopt.optimize(opt, x0)
     alg.current_optimal_x[:] = minx
     return minx
 end


### PR DESCRIPTION
This resolves the issue of the starting point being out of bounds if zero is not within the domain of a particular dimension (and NLOpt then crashing due to a failed check)

I've checked it with Laurens Bliek to be sure, and this is likely the correct behaviour.